### PR TITLE
Add "curator" role

### DIFF
--- a/IFComp/lib/IFComp.pm
+++ b/IFComp/lib/IFComp.pm
@@ -20,6 +20,7 @@ use Catalyst qw/
     ConfigLoader
     Static::Simple
     Authentication
+    Authorization::Roles
     Session
     Session::Store::DBIC
     Session::State::Cookie
@@ -59,6 +60,8 @@ __PACKAGE__->config(
                 class => "DBIx::Class",
                 user_model => "IFCompDB::User",
                 store_user_class => 'IFComp::UserStore',
+                role_relation => 'roles',
+                role_field => 'name',
             },
         },
     },

--- a/IFComp/lib/IFComp/Controller/Ballot.pm
+++ b/IFComp/lib/IFComp/Controller/Ballot.pm
@@ -30,6 +30,7 @@ sub root :Chained('/') :PathPart('ballot') :CaptureArgs(0) {
     unless (
         $current_comp->status eq 'open_for_judging'
         || $current_comp->status eq 'processing_votes'
+        || $c->check_user_roles( 'curator' )
     ) {
         $c->res->redirect( $c->uri_for_action( '/comp/comp' ) );
         return;

--- a/IFComp/lib/IFComp/Controller/Play.pm
+++ b/IFComp/lib/IFComp/Controller/Play.pm
@@ -36,6 +36,7 @@ sub fetch_entry :Chained('root') :PathPart('') :CaptureArgs(1) {
             || ( $c->stash->{ current_comp }->status eq 'processing_votes' )
             || ( $c->stash->{ current_comp }->status eq 'over' )
             || ( $c->user && ( $entry->author->id eq $c->user->id ) )
+            || ( $c->check_user_roles( 'curator' ) )
         ) {
             $c->res->redirect( $c->uri_for_action( '/comp/comp' ) );
         }

--- a/IFComp/lib/IFComp/Schema/Result/User.pm
+++ b/IFComp/lib/IFComp/Schema/Result/User.pm
@@ -260,6 +260,8 @@ __PACKAGE__->has_many(
 # Created by DBIx::Class::Schema::Loader v0.07039 @ 2015-05-10 11:16:28
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:BBT/++Ap+7+u+Yf2VVYl0A
 
+__PACKAGE__->many_to_many('roles' => 'user_roles', 'role');
+
 use Digest::MD5 ('md5_hex');
 use Email::Sender::Simple qw/ sendmail /;
 use Email::MIME::Kit;

--- a/IFComp/lib/Plack/Middleware/IFComp.pm
+++ b/IFComp/lib/Plack/Middleware/IFComp.pm
@@ -90,7 +90,13 @@ sub call {
                     my $session_ref = thaw( decode_base64( $session_row->session_data ) );
                     if ( $session_ref->{ __user } ) {
                         my $user_id = $session_ref->{ __user }->{ id };
+                        my $user =
+                            $self->schema->resultset( 'User' )->find( $user_id )
+                        ;
                         if ( $user_id == $entry->author->id ) {
+                            $current_user_can_see_this_game = 1;
+                        }
+                        elsif ( grep { $_->name eq 'curator' } $user->roles->all ) {
                             $current_user_can_see_this_game = 1;
                         }
                     }


### PR DESCRIPTION
This activates the role-based authorization support that the web app has had lurking unimplemented via its heretofore empty `role` and `user_role` tables.

It also allows users with the "curator" role to see the ballot page and browse/play its entries at any time, even if the public can't see them yet.

The purpose is to allow IFComp staff to browse submitted entries before the competition opens to the public.