### PR TITLE
Issue 63: Create a play_file attribute for entries to to show which file to link to from play online

### DIFF
--- a/IFComp/lib/IFComp/Controller/Play.pm
+++ b/IFComp/lib/IFComp/Controller/Play.pm
@@ -54,12 +54,7 @@ sub play_online :Chained('fetch_entry') :Args(0) {
     my $entry = $c->stash->{ entry };
     my $entry_id = $entry->id;
     my $redirection_target = '';
-    if ( $entry->platform eq 'html' ) {
-        $redirection_target = $entry->main_file->basename;
-    }
-    else {
-        $redirection_target = 'index.html';
-    }
+    $redirection_target = $entry->play_file->stringify;
 
     my $redirection_path = "/$entry_id/content/$redirection_target";
     $c->res->redirect( $c->uri_for( $redirection_path ) );

--- a/README.md
+++ b/README.md
@@ -33,15 +33,18 @@ To install this project's CPAN dependencies, run the following command from the 
 
 This should crunch though the installation of a bunch of Perl modules. It'll take a few minutes.
 
-## Database configuration
-
-I hear rumors that one can construct a database based on the provided `IFComp::Schema` library, but that is magic presently beyond my ken.
-
-Otherwise, this information will appear someday...
-
 ## Application configuration
 
-Copy `conf/ifcomp_local.conf-dist` to `conf/ifcomp.local` and then update the database pointers therein as appropriate.
+Copy `conf/ifcomp_local.conf-dist` to `conf/ifcomp_local.conf` and then update the database pointers therein as appropriate.
+
+## Database configuration
+
+Run script/ifcomp_deploy_db.pl to construct the database tables (having first
+created the database, user, and password, and set up the application
+configuration appropriately). Note this script won't fill in the role table,
+the comp table, or the federated_site table. The last of these isn't required
+for most operation, but the first two do need to be manually filled in once
+the tables are created.
 
 ## Making it go
 


### PR DESCRIPTION
This patch makes it so at the time the platform is generated (by analyzing the uploaded files), it also picks one file as the play_file. For the web platforms, this file is linked to by play online (the play file doesn't get used for the non-web platforms, but you can imagine down the line the site could generate a custom parchment build based on the file or something).