### PR TITLE
Issue 64: json is already a string, not bytes, so use from_json instead

### DIFF
--- a/IFComp/lib/IFComp/Controller/Play.pm
+++ b/IFComp/lib/IFComp/Controller/Play.pm
@@ -95,7 +95,7 @@ sub transcribe :Chained('fetch_entry') :Args(0) {
 
     my $data_ref = $c->req->body_data->{ data };
     unless ( ref $data_ref ) {
-        $data_ref = decode_json( $data_ref );
+        $data_ref = from_json( $data_ref );
     }
 
     my $data_list_ref;


### PR DESCRIPTION
This is hard for me to test locally for obvious reasons, but I was able to do some sample code that also showed the issue, so I think this is the right fix. Basically, I think req->body_data has already been converted from bytes to a string, so decode_json is the wrong function; from_json is what you use for strings.