### PR TITLE
Ballot crontasks

### DIFF
--- a/IFComp/cpanfile
+++ b/IFComp/cpanfile
@@ -36,6 +36,7 @@ requires 'Template::Plugin::Comma';
 requires 'Template::Plugin::DateTime';
 requires 'Regexp::Common';
 requires 'File::MimeInfo';
+requires 'Statistics::Basic';
 
 test_requires 'Test::More' => '0.88';
 test_requires 'Test::WWW::Mechanize::Catalyst';

--- a/IFComp/lib/IFComp/Schema/Result/VoteFromQualifiedJudgeBallot.pm
+++ b/IFComp/lib/IFComp/Schema/Result/VoteFromQualifiedJudgeBallot.pm
@@ -1,0 +1,60 @@
+package IFComp::Schema::Result::VoteFromQualifiedJudgeBallot;
+use strict;
+use warnings;
+use base qw/DBIx::Class::Core/;
+
+# This class provides a view onto the `vote` table that restricts results to
+# non-entrants of a given competition, and also only to voters who have
+# submitted at least five entries.
+#
+# To use it, you'll need to pass in a 'bind' attribute set to the comp id.
+#
+# For a usage example, see script/update_current_rating_tallies.
+
+__PACKAGE__->table_class('DBIx::Class::ResultSource::View');
+
+__PACKAGE__->table( 'judge_votes' );
+
+__PACKAGE__->add_columns(
+                         "id",
+                         {
+                          data_type => "integer",
+                          extra => { unsigned => 1 },
+                          is_auto_increment => 1,
+                          is_nullable => 0,
+                         },
+                         "user",
+                         {
+                          data_type => "integer",
+                          extra => { unsigned => 1 },
+                          is_foreign_key => 1,
+                          is_nullable => 0,
+                         },
+                         "score",
+                         {
+                          data_type => "tinyint", is_nullable => 0 },
+                         "entry",
+                         {
+                          data_type => "integer",
+                          extra => { unsigned => 1 },
+                          is_foreign_key => 1,
+                          is_nullable => 0,
+                         },
+                         "time",
+                         {
+                          data_type => "datetime",
+                          datetime_undef_if_invalid => 1,
+                          is_nullable => 1,
+                         },
+                         "ip",
+                         {
+                          data_type => "char", default_value => "", is_nullable => 0, size => 15 },
+                        );
+
+__PACKAGE__->result_source_instance->is_virtual(1);
+
+__PACKAGE__->result_source_instance->view_definition(q[
+select v.* from entry e, vote v left join entry o on (v.user = o.author and o.comp = ?) where e.comp = 26 and v.entry = e.id and (o.author is null or o.is_disqualified = 1) and v.user in (select user from vote, entry where entry.id = vote.entry and entry.comp = ? group by user having count(score) >= 5)
+]);
+
+1;

--- a/IFComp/script/update_current_rating_tallies
+++ b/IFComp/script/update_current_rating_tallies
@@ -15,11 +15,11 @@ my $schema = IFComp::Schema->connect( 'dbi:mysql:ifcomp', 'root', '' );
 $schema->entry_directory( Path::Class::Dir->new( "$FindBin::Bin/../entries" ) );
 
 my $current_comp = $schema->resultset( 'Comp' )->current_comp;
-my $vote_rs = $schema->resultset( 'Vote' );
+my $vote_rs = $schema->resultset( 'VoteFromQualifiedJudgeBallot' );
 
 for my $entry ( $current_comp->entries ) {
     next unless $entry->is_qualified;
-    
+
     my %votes;
     my $standard_dev;
     my $mean;
@@ -27,16 +27,21 @@ for my $entry ( $current_comp->entries ) {
     my @scores;
 
     for my $score ( 1..10 ) {
-	my $count = $vote_rs->search( {
-	    entry => $entry->id,
-	    score => $score,			      
-        } )->count;
-	
-	$votes{ "total_$score" } = $count;
-	$total_votes += $count;
-	foreach ( 1..$count ) {
-	    push @scores, $score;
-	}
+    	my $count = $vote_rs->search(
+	        {
+	            entry => $entry->id,
+    	        score => $score,
+            },
+            {
+                bind  => [ $current_comp->id ],
+            },
+        )->count;
+
+    	$votes{ "total_$score" } = $count;
+	    $total_votes += $count;
+    	foreach ( 1..$count ) {
+	        push @scores, $score;
+    	}
     }
 
     next unless $total_votes;
@@ -52,5 +57,5 @@ for my $entry ( $current_comp->entries ) {
     );
 
     $entry->update ( \%update_args );
-    
+
 }

--- a/IFComp/script/update_current_rating_tallies
+++ b/IFComp/script/update_current_rating_tallies
@@ -1,0 +1,56 @@
+#!/usr/bin/env perl
+
+# This script updates various derived-value fields for the current comp's
+# qualified entry records. Can be cron as a regular crontask.
+
+use warnings;
+use strict;
+use FindBin;
+use Statistics::Basic qw( stddev mean );
+
+use lib "$FindBin::Bin/../lib";
+use IFComp::Schema;
+
+my $schema = IFComp::Schema->connect( 'dbi:mysql:ifcomp', 'root', '' );
+$schema->entry_directory( Path::Class::Dir->new( "$FindBin::Bin/../entries" ) );
+
+my $current_comp = $schema->resultset( 'Comp' )->current_comp;
+my $vote_rs = $schema->resultset( 'Vote' );
+
+for my $entry ( $current_comp->entries ) {
+    next unless $entry->is_qualified;
+    
+    my %votes;
+    my $standard_dev;
+    my $mean;
+    my $total_votes;
+    my @scores;
+
+    for my $score ( 1..10 ) {
+	my $count = $vote_rs->search( {
+	    entry => $entry->id,
+	    score => $score,			      
+        } )->count;
+	
+	$votes{ "total_$score" } = $count;
+	$total_votes += $count;
+	foreach ( 1..$count ) {
+	    push @scores, $score;
+	}
+    }
+
+    next unless $total_votes;
+
+    $standard_dev = stddev( @scores );
+    $mean = mean( @scores );
+
+    my %update_args = (
+	average_score => $mean,
+	standard_deviation => $standard_dev,
+	votes_cast => $total_votes,
+	%votes,
+    );
+
+    $entry->update ( \%update_args );
+    
+}


### PR DESCRIPTION
This adds the following:

* A new 'virtual' resultset, VoteFromQualifiedJudgeBallot, that provides a (read-only) view to the Vote table with the following restrictions:
    * Counts only ballots containing at least five ratings
    * Disregards ballots from the given competition's entrants

* A script, intended to be run as a crontask, that updates all the derived fields for the current comp's qualified entries.
