### PR TITLE
Add perltidy and tidyall config, prereqs, and test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 IFComp/conf/ifcomp_local.conf
+.tidyall.d

--- a/.tidyallrc
+++ b/.tidyallrc
@@ -1,0 +1,3 @@
+[PerlTidy]
+select = **/*.{pl,pm,t,psgi}
+argv = --profile=$ROOT/IFComp/.perltidyrc

--- a/IFComp/.perltidyrc
+++ b/IFComp/.perltidyrc
@@ -1,0 +1,16 @@
+-l=78   # Max line width is 78 cols
+-i=4    # Indent level is 4 cols
+-ci=4   # Continuation indent is 2 cols
+-vt=2   # Maximal vertical tightness
+-cti=0  # No extra indentation for closing brackets
+-pt=1   # Medium parenthesis tightness
+-sbt=1  # Medium square bracket tightness
+-bt=1   # Medium brace tightness
+-bbt=1  # Medium block brace tightness
+-nsfs   # No space before semicolons
+-nolq   # Don't outdent long quoted strings
+-nolc   # Long comments indented, even when this make the total line length "too long"
+-noll   # Long lines indented, even when this make the total line length "too long"
+-nola   # Don't treat labels as special cases when indenting
+        # Break before all operators
+-wbb="% + - * / x != == >= <= =~ !~ < > | & **= += *= &= <<= &&= -= /= |= >>= ||= .= %= ^= x="

--- a/IFComp/cpanfile
+++ b/IFComp/cpanfile
@@ -41,3 +41,8 @@ requires 'File::MimeInfo';
 
 test_requires 'Test::More' => '0.88';
 test_requires 'Test::WWW::Mechanize::Catalyst';
+
+on 'develop' => sub {
+  requires 'Code::TidyAll';
+  requires 'Perl::Tidy';
+};

--- a/IFComp/xt/tidyall.t
+++ b/IFComp/xt/tidyall.t
@@ -1,0 +1,3 @@
+#!/usr/bin/perl
+use Test::Code::TidyAll;
+tidyall_ok();


### PR DESCRIPTION
This adds Perl::Tidy and Code::TidyAll to the prereqs, along with configs for each.

Perl::Tidy is a module and CLI tool for parsing and prettifying perl code. Code::TidyAll is a module and CLI tool for running various formatters and validators. It's only set up to run Perl::Tidy here, but there are many other options we can add later, eg Perl::Critic or PodChecker.

perltidy will format code according to a set of rules, in IFComp/.perltidyrc. This is the same config I've been using for years, and is generally the same as the style recommended by Perl Best Practices.

This PR is less about prescribing this formatting style in particular, and more about getting the tooling in place so that we can start to establish and encourage some set of coding standards. This config seems as good a place to start as any.

The two most salient settings are probably a) it uses spaces, not tabs, and b) it sets lines to a max length of 78 characters.

I tidied the entire codebase in a separate branch, so everyone can see how things are reformatted, without it necessarily being pulled at the same time as this PR: https://github.com/jmacdotorg/ifcomp/tree/tidy-codebase

I'm not sure if it's worth tidying the entire codebase all at once, or just tidying files as we would change them otherwise. In either case, I think that tidying code should be done in its own commit, separate from functional changes.

### CLI Usage:

Tidy a single file: `tidyall filename.pm`
Tidy files added/changed in git repo: `tidyall -g`
Tidy all files: `tidyall -a`

### Editor integration:

The Code::TidyAll distribution includes configs for calling tidyall from within Emacs and Vim: https://github.com/houseabsolute/perl-code-tidyall/tree/master/etc/editors

### Git hook:

Code::TidyAll also includes a precommit git hook: https://metacpan.org/pod/Code::TidyAll::Git::Precommit

When this is installed (by copying and pasting 6 lines into your .git/hooks/precommit), it will ensure that any files being committed have been tidied. It can be overriden by running git commit with the '--no-verify' flag.
