### PR TITLE
Quote attachment name in Content-Disposition header.

### DIFF
--- a/IFComp/lib/IFComp/Controller/Play.pm
+++ b/IFComp/lib/IFComp/Controller/Play.pm
@@ -84,7 +84,7 @@ sub download :Chained('fetch_entry') :Args(0) {
             $body =~ s/es6-shim.*//s;
             $body .= $shim_text;
         }
-        $c->res->header( 'Content-Disposition' => "attachment; filename=$filename" );
+        $c->res->header( 'Content-Disposition' => qq{attachment; filename="$filename"} );
         $c->res->content_type( 'text/html' );
         $c->res->code( 200 );
         $c->res->body( $body );


### PR DESCRIPTION
Filenames with commas cause Chrome to interpret the header as two
headers. That is,

    Content-Disposition: attachment; filename=SCREW YOU, BEAR DAD.html

is interpreted as

    Content-Disposition: attachment; filename=SCREW YOU
    Content-Disposition: BEAR DAD.html

Quoting the filename should fix this issue.